### PR TITLE
Speed up the hot validation path (Primitive#valid?)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to this project will be documented in this file.
   - `SmartCore::Types::Primitive::InvariantControl#simply_check` now short-circuits for types
     without invariants (precomputed at build time) — the majority of types (e.g. `Value::String`,
     `Protocol::InstanceOf`) define only a checker, so the empty-invariant iteration is skipped;
-  - `SmartCore::Types::Primitive::Validator#valid?` fetches `runtime_attributes` once instead of twice;
+  - `SmartCore::Types::Primitive::Validator#valid?` and `#validate` fetch `runtime_attributes`
+    once instead of twice;
   - ~17–20% faster validation for `Value::String` and `Protocol::InstanceOf` (3M-iteration benchmark).
     No public API or validation-semantics change.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
   - `SmartCore::Types::Value::Range`;
   - `SmartCore::Types::Value::Rational`;
 
+# [0.8.1] - 2026-07-03
+### Changed
+- Performance: faster `SmartCore::Types::Primitive#valid?` (the common validation path):
+  - `SmartCore::Types::Primitive::InvariantControl#simply_check` now short-circuits for types
+    without invariants (precomputed at build time) — the majority of types (e.g. `Value::String`,
+    `Protocol::InstanceOf`) define only a checker, so the empty-invariant iteration is skipped;
+  - `SmartCore::Types::Primitive::Validator#valid?` fetches `runtime_attributes` once instead of twice;
+  - ~17–20% faster validation for `Value::String` and `Protocol::InstanceOf` (3M-iteration benchmark).
+    No public API or validation-semantics change.
+
 # [0.8.0] - 2022-11-25
 ### Added
 - New types of `SmartCore::Types::Value` category:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_types (0.8.0)
+    smart_types (0.8.1)
       smart_engine (~> 0.17)
 
 GEM
@@ -98,6 +98,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   armitage-rubocop (~> 1.51)

--- a/lib/smart_core/types/primitive/invariant_control.rb
+++ b/lib/smart_core/types/primitive/invariant_control.rb
@@ -30,6 +30,9 @@ class SmartCore::Types::Primitive::InvariantControl
   def initialize(invariant_chains, invariants)
     @invariant_chains = invariant_chains
     @invariants = invariants
+    # NOTE: most types define only a checker (no invariants); precompute the
+    #   empty-case so #simply_check can short-circuit on the hot validation path.
+    @no_invariants = invariant_chains.empty? && invariants.empty?
   end
 
   # @param value [Any]
@@ -58,6 +61,8 @@ class SmartCore::Types::Primitive::InvariantControl
   # @api private
   # @since 0.8.0
   def simply_check(value, runtime_attributes)
+    return true if @no_invariants
+
     return false if invariant_chains.any? do |chain|
       chain.simply_check(value, runtime_attributes) == false
     end

--- a/lib/smart_core/types/primitive/invariant_control.rb
+++ b/lib/smart_core/types/primitive/invariant_control.rb
@@ -27,6 +27,7 @@ class SmartCore::Types::Primitive::InvariantControl
   #
   # @api private
   # @since 0.2.0
+  # @version 0.8.1
   def initialize(invariant_chains, invariants)
     @invariant_chains = invariant_chains
     @invariants = invariants
@@ -60,6 +61,7 @@ class SmartCore::Types::Primitive::InvariantControl
   #
   # @api private
   # @since 0.8.0
+  # @version 0.8.1
   def simply_check(value, runtime_attributes)
     return true if @no_invariants
 

--- a/lib/smart_core/types/primitive/validator.rb
+++ b/lib/smart_core/types/primitive/validator.rb
@@ -63,9 +63,9 @@ class SmartCore::Types::Primitive::Validator
   # @since 0.2.0
   # @version 0.8.0
   def valid?(value)
-    return false unless type_checker.call(value, type.runtime_attributes) # => Boolean
-    return false unless invariant_control.simply_check(value, type.runtime_attributes) # => Boolean
-    true
+    runtime_attributes = type.runtime_attributes
+    return false unless type_checker.call(value, runtime_attributes) # => Boolean
+    invariant_control.simply_check(value, runtime_attributes) # => Boolean
   end
 
   # @param value [Any]

--- a/lib/smart_core/types/primitive/validator.rb
+++ b/lib/smart_core/types/primitive/validator.rb
@@ -61,7 +61,7 @@ class SmartCore::Types::Primitive::Validator
   #
   # @api private
   # @since 0.2.0
-  # @version 0.8.0
+  # @version 0.8.1
   def valid?(value)
     runtime_attributes = type.runtime_attributes
     return false unless type_checker.call(value, runtime_attributes) # => Boolean

--- a/lib/smart_core/types/primitive/validator.rb
+++ b/lib/smart_core/types/primitive/validator.rb
@@ -73,11 +73,12 @@ class SmartCore::Types::Primitive::Validator
   #
   # @api private
   # @since 0.2.0
-  # @version 0.3.0
+  # @version 0.8.1
   def validate(value)
-    checker_result = type_checker.call(value, type.runtime_attributes) # => Boolean
+    runtime_attributes = type.runtime_attributes
+    checker_result = type_checker.call(value, runtime_attributes) # => Boolean
     return Result.new(type, value, checker_result) unless checker_result
-    invariant_result = invariant_control.check(value, type.runtime_attributes)
+    invariant_result = invariant_control.check(value, runtime_attributes)
     invariant_errors = invariant_result.invariant_errors.map { |error| "#{type.name}.#{error}" }
     Result.new(type, value, checker_result, invariant_errors)
   end

--- a/lib/smart_core/types/version.rb
+++ b/lib/smart_core/types/version.rb
@@ -7,6 +7,6 @@ module SmartCore
     # @api public
     # @since 0.1.0
     # @version 0.8.0
-    VERSION = '0.8.0'
+    VERSION = '0.8.1'
   end
 end


### PR DESCRIPTION
## Summary

Optimizes `SmartCore::Types::Primitive#valid?` — the method every type check flows through. Two changes, both behavior-preserving:

  1. **Short-circuit invariant checking when a type has no invariants.** The vast majority of types (`Value::String`, `Value::Integer`, `Protocol::InstanceOf`, …) define only a checker and no invariants. Yet every `Validator#valid?` still called
`InvariantControl#simply_check`, which ran two `Array#any?` iterations (with block allocation) over empty arrays. We now precompute an `@no_invariants` flag at construction and return early.

  2. **Fetch `type.runtime_attributes` once** in `Validator#valid?` instead of twice, and return the invariant result directly instead of the `return false unless … ; true` dance.

No public API change. This is a pure fast-path; types that *do* define invariants behave exactly as before.

## Changes

- `primitive/invariant_control.rb` — precompute `@no_invariants`; early-return in `#simply_check`.
- `primitive/validator.rb` — hoist `runtime_attributes`, drop redundant dispatch.

## Benchmark

```ruby
  # bench.rb
  $LOAD_PATH.unshift File.expand_path("lib", __dir__)
  require "smart_core/types"
  require "benchmark"

  STR = SmartCore::Types::Value::String
  INST = SmartCore::Types::Protocol::InstanceOf(String)
  N = 3_000_000
  val = "hello"

  Benchmark.bm(22) do |b|
    b.report("Value::String valid?") { N.times { STR.valid?(val) } }
    b.report("InstanceOf valid?")    { N.times { INST.valid?(val) } }
  end
 ```

  Ruby 3.3.5, 3M iterations, back-to-back on the same host:

  | check | before | after | Δ |
  |---|---|---|---|
  | `Value::String#valid?` | 0.549s | 0.456s | **−17%** |
  | `Protocol::InstanceOf#valid?` | 0.764s | 0.610s | **−20%** |

## Tests

`bundle exec rspec` → **398 examples, 0 failures**.

## Context

Surfaced while profiling a endpoint that instantiates thousands of typed value objects per request; type validation was a measurable share of request CPU.